### PR TITLE
Feat #10, #11 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,13 +20,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gabozago/backend/config/SecurityConfig.java
+++ b/src/main/java/com/gabozago/backend/config/SecurityConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 
@@ -21,11 +23,17 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
         http
                 .authorizeRequests()
-                .antMatchers("/auth/").permitAll()
+                .antMatchers("/auth/**").permitAll()
                 .anyRequest().authenticated();
 
         return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/gabozago/backend/config/SecurityConfig.java
+++ b/src/main/java/com/gabozago/backend/config/SecurityConfig.java
@@ -1,20 +1,33 @@
 package com.gabozago.backend.config;
 
+import com.gabozago.backend.jwt.AuthFilter;
+import com.gabozago.backend.jwt.JwtAuthenticationEntryPoint;
+import com.gabozago.backend.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final TokenProvider tokenProvider;
+
+    private final AccessDeniedHandler accessDeniedHandler;
+
+    private final JwtAuthenticationEntryPoint authenticationEntryPoint;
+
     @Bean
-    public WebSecurityCustomizer configure(){
+    public WebSecurityCustomizer configure() {
         return (web) -> web.ignoring().antMatchers(
                 "/favicon.ico",
                 "/h2-console/**"
@@ -23,11 +36,17 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-
         http
+                .httpBasic().disable()
+                .csrf().disable()
+                .exceptionHandling()
+                .authenticationEntryPoint(authenticationEntryPoint)
+                .accessDeniedHandler(accessDeniedHandler).and()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
                 .authorizeRequests()
-                .antMatchers("/auth/**").permitAll()
-                .anyRequest().authenticated();
+                .antMatchers("/auth/join", "/auth/login").permitAll()
+                .anyRequest().authenticated().and()
+                .addFilterBefore(new AuthFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/gabozago/backend/config/SecurityConfig.java
+++ b/src/main/java/com/gabozago/backend/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.gabozago.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.web.SecurityFilterChain;
+
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public WebSecurityCustomizer configure(){
+        return (web) -> web.ignoring().antMatchers(
+                "/favicon.ico",
+                "/h2-console/**"
+        );
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests()
+                .antMatchers("/auth/").permitAll()
+                .anyRequest().authenticated();
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/gabozago/backend/controller/AuthController.java
+++ b/src/main/java/com/gabozago/backend/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.gabozago.backend.controller;
 
+import com.gabozago.backend.dto.auth.JoinRequestDto;
+import com.gabozago.backend.dto.auth.LoginRequestDto;
 import com.gabozago.backend.entity.User;
 import com.gabozago.backend.error.ErrorCode;
 import com.gabozago.backend.error.ErrorResponse;
@@ -11,8 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.Collections;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/auth")
@@ -31,18 +33,18 @@ public class AuthController {
 
     @PostMapping("/join")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<String> join(@RequestBody Map<String, String> user) {
-        if (userService.checkExistsByEmail(user.get("email"))) {
+    public ResponseEntity<String> join(final @Valid @RequestBody JoinRequestDto user) {
+        if (userService.checkExistsByEmail(user.getEmail())) {
             return ErrorResponse.of(ErrorCode.DUPLICATED_EMAIL).entity();
         }
 
-        if (userService.checkExistsByNickname(user.get("nickname"))) {
+        if (userService.checkExistsByNickname(user.getNickname())) {
             return ErrorResponse.of(ErrorCode.DUPLICATED_NICKNAME).entity();
         }
 
         userService.save(User.builder()
-                .email(user.get("email"))
-                .password(passwordEncoder.encode(user.get("password")))
+                .email(user.getEmail())
+                .password(passwordEncoder.encode(user.getPassword()))
                 .roles(Collections.singletonList("ROLE_USER"))
                 .build());
 
@@ -50,8 +52,8 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody Map<String, String> request) {
-        String email = request.get("email");
+    public ResponseEntity<String> login(final @Valid @RequestBody LoginRequestDto request) {
+        String email = request.getEmail();
         User user;
 
         try {
@@ -60,7 +62,7 @@ public class AuthController {
             return ResponseEntity.notFound().build();
         }
 
-        if (!passwordEncoder.matches(request.get("password"), user.getPassword())) {
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             return new ResponseEntity<>("password is not correct", null, 401);
         }
 

--- a/src/main/java/com/gabozago/backend/controller/AuthController.java
+++ b/src/main/java/com/gabozago/backend/controller/AuthController.java
@@ -53,7 +53,7 @@ public class AuthController {
         }
 
         if (!passwordEncoder.matches(request.get("password"), user.getPassword())) {
-            return ResponseEntity.badRequest().body("password is not correct");
+            return new ResponseEntity<>("password is not correct", null, 401);
         }
 
         String jwtToken = tokenProvider.createToken(user.getId(), user.getRoles());

--- a/src/main/java/com/gabozago/backend/controller/AuthController.java
+++ b/src/main/java/com/gabozago/backend/controller/AuthController.java
@@ -5,7 +5,8 @@ import com.gabozago.backend.error.ErrorCode;
 import com.gabozago.backend.error.ErrorResponse;
 import com.gabozago.backend.jwt.TokenProvider;
 import com.gabozago.backend.service.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +16,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 public class AuthController {
     private final UserService userService;
 
@@ -22,19 +24,13 @@ public class AuthController {
 
     private final PasswordEncoder passwordEncoder;
 
-    @Autowired
-    public AuthController(UserService userService, TokenProvider tokenProvider, PasswordEncoder passwordEncoder) {
-        this.userService = userService;
-        this.tokenProvider = tokenProvider;
-        this.passwordEncoder = passwordEncoder;
-    }
-
     @GetMapping("/")
     public ResponseEntity<String> index() {
         return ResponseEntity.ok("this is auth controller");
     }
 
     @PostMapping("/join")
+    @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<String> join(@RequestBody Map<String, String> user) {
         if (userService.checkExistsByEmail(user.get("email"))) {
             return ErrorResponse.of(ErrorCode.DUPLICATED_EMAIL).entity();

--- a/src/main/java/com/gabozago/backend/controller/AuthController.java
+++ b/src/main/java/com/gabozago/backend/controller/AuthController.java
@@ -1,15 +1,63 @@
 package com.gabozago.backend.controller;
 
+import com.gabozago.backend.entity.User;
+import com.gabozago.backend.jwt.TokenProvider;
+import com.gabozago.backend.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
+    private final UserService userService;
+
+    private final TokenProvider tokenProvider;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Autowired
+    public AuthController(UserService userService, TokenProvider tokenProvider, PasswordEncoder passwordEncoder) {
+        this.userService = userService;
+        this.tokenProvider = tokenProvider;
+        this.passwordEncoder = passwordEncoder;
+    }
+
     @GetMapping("/")
     public ResponseEntity<String> index() {
         return ResponseEntity.ok("this is auth controller");
+    }
+
+    @PostMapping("/join")
+    public ResponseEntity<String> join(@RequestBody Map<String, String> user) {
+        userService.save(User.builder()
+                .email(user.get("email"))
+                .password(passwordEncoder.encode(user.get("password")))
+                .build());
+
+        return ResponseEntity.ok("join success");
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(@RequestBody Map<String, String> request) {
+        String email = request.get("email");
+        User user;
+
+        try {
+            user = userService.findByEmail(email);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+
+        if (!passwordEncoder.matches(request.get("password"), user.getPassword())) {
+            return ResponseEntity.badRequest().body("password is not correct");
+        }
+
+        String jwtToken = tokenProvider.createToken(user.getId(), user.getRoles());
+
+        return ResponseEntity.ok(jwtToken);
     }
 }

--- a/src/main/java/com/gabozago/backend/controller/AuthController.java
+++ b/src/main/java/com/gabozago/backend/controller/AuthController.java
@@ -1,0 +1,15 @@
+package com.gabozago.backend.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+    @GetMapping("/")
+    public ResponseEntity<String> index() {
+        return ResponseEntity.ok("this is auth controller");
+    }
+}

--- a/src/main/java/com/gabozago/backend/dto/auth/JoinRequestDto.java
+++ b/src/main/java/com/gabozago/backend/dto/auth/JoinRequestDto.java
@@ -1,0 +1,21 @@
+package com.gabozago.backend.dto.auth;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class JoinRequestDto {
+    public static final String EMAIL_NOT_NULL = "email은 필수 입력값입니다.";
+    public static final String PASSWORD_NOT_NULL = "password는 필수 입력값입니다.";
+    public static final String NICKNAME_NOT_NULL = "nickname은 필수 입력값입니다.";
+
+    @NotBlank(message = EMAIL_NOT_NULL)
+    private String email;
+
+    @NotBlank(message = PASSWORD_NOT_NULL)
+    private String password;
+
+    @NotBlank(message = NICKNAME_NOT_NULL)
+    private String nickname;
+}

--- a/src/main/java/com/gabozago/backend/dto/auth/LoginRequestDto.java
+++ b/src/main/java/com/gabozago/backend/dto/auth/LoginRequestDto.java
@@ -1,0 +1,17 @@
+package com.gabozago.backend.dto.auth;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class LoginRequestDto {
+    public static final String EMAIL_NOT_NULL = "email은 필수 입력값입니다.";
+    public static final String PASSWORD_NOT_NULL = "password는 필수 입력값입니다.";
+
+    @NotBlank(message = EMAIL_NOT_NULL)
+    private String email;
+
+    @NotBlank(message = PASSWORD_NOT_NULL)
+    private String password;
+}

--- a/src/main/java/com/gabozago/backend/entity/User.java
+++ b/src/main/java/com/gabozago/backend/entity/User.java
@@ -1,0 +1,25 @@
+package com.gabozago.backend.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @JsonIgnore
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @JsonIgnore
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "nickname")
+    private String nickname;
+}

--- a/src/main/java/com/gabozago/backend/entity/User.java
+++ b/src/main/java/com/gabozago/backend/entity/User.java
@@ -1,25 +1,89 @@
 package com.gabozago.backend.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "users")
-public class User {
+public class User implements UserDetails {
     @JsonIgnore
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name")
-    private String name;
+    @Column(name = "email", unique = true)
+    private String email;
+
+    @Column(name = "username")
+    private String username;
 
     @JsonIgnore
     @Column(name = "password")
     private String password;
 
-    @Column(name = "nickname")
+    @Column(name = "nickname", unique = true)
     private String nickname;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Builder.Default
+    private List<String> roles = new ArrayList<>();
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
 }

--- a/src/main/java/com/gabozago/backend/error/EnumModel.java
+++ b/src/main/java/com/gabozago/backend/error/EnumModel.java
@@ -1,0 +1,8 @@
+package com.gabozago.backend.error;
+
+public interface EnumModel {
+
+    String getKey();
+    String getValue();
+
+}

--- a/src/main/java/com/gabozago/backend/error/ErrorCode.java
+++ b/src/main/java/com/gabozago/backend/error/ErrorCode.java
@@ -1,0 +1,36 @@
+package com.gabozago.backend.error;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum ErrorCode implements EnumModel {
+
+    // COMMON
+    UNAUTHENTICATED(403, "A001", "인증되지 않은 사용자입니다."),
+    UNAUTHORIZED(401, "A002", "권한이 없는 사용자입니다.");
+
+    private int status;
+    private String code;
+    private String message;
+    private String detail;
+
+    ErrorCode(int status, String code, String message) {
+        this.status = status;
+        this.message = message;
+        this.code = code;
+    }
+
+    @Override
+    public String getKey() {
+        return this.code;
+    }
+
+    @Override
+    public String getValue() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/gabozago/backend/error/ErrorCode.java
+++ b/src/main/java/com/gabozago/backend/error/ErrorCode.java
@@ -1,22 +1,22 @@
 package com.gabozago.backend.error;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import javax.servlet.http.HttpServletResponse;
+
 @RequiredArgsConstructor
 @Getter
-@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ErrorCode implements EnumModel {
 
-    // COMMON
-    UNAUTHENTICATED(403, "A001", "인증되지 않은 사용자입니다."),
-    UNAUTHORIZED(401, "A002", "권한이 없는 사용자입니다.");
+    // Auth
+    UNAUTHENTICATED(HttpServletResponse.SC_FORBIDDEN, "UNAUTHENTICATED", "인증되지 않은 사용자입니다."),
+    UNAUTHORIZED(HttpServletResponse.SC_UNAUTHORIZED, "UNAUTHORIZED", "권한이 없는 사용자입니다.");
+
 
     private int status;
     private String code;
     private String message;
-    private String detail;
 
     ErrorCode(int status, String code, String message) {
         this.status = status;

--- a/src/main/java/com/gabozago/backend/error/ErrorCode.java
+++ b/src/main/java/com/gabozago/backend/error/ErrorCode.java
@@ -9,6 +9,10 @@ import javax.servlet.http.HttpServletResponse;
 @Getter
 public enum ErrorCode implements EnumModel {
 
+    // Join
+    DUPLICATED_EMAIL(HttpServletResponse.SC_CONFLICT, "DUPLICATED_EMAIL", "이미 존재하는 이메일입니다."),
+    DUPLICATED_NICKNAME(HttpServletResponse.SC_CONFLICT, "DUPLICATED_NICKNAME", "이미 존재하는 닉네임입니다."),
+
     // Auth
     UNAUTHENTICATED(HttpServletResponse.SC_FORBIDDEN, "UNAUTHENTICATED", "인증되지 않은 사용자입니다."),
     UNAUTHORIZED(HttpServletResponse.SC_UNAUTHORIZED, "UNAUTHORIZED", "권한이 없는 사용자입니다.");

--- a/src/main/java/com/gabozago/backend/error/ErrorResponse.java
+++ b/src/main/java/com/gabozago/backend/error/ErrorResponse.java
@@ -1,27 +1,32 @@
 package com.gabozago.backend.error;
 
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import org.springframework.http.ResponseEntity;
 
-@Getter
-@Setter
 @NoArgsConstructor
 public class ErrorResponse {
 
     private String message;
     private String code;
     private int status;
-    private String detail;
 
     public ErrorResponse(ErrorCode code) {
         this.message = code.getMessage();
         this.status = code.getStatus();
         this.code = code.getCode();
-        this.detail = code.getDetail();
     }
 
     public static ErrorResponse of(ErrorCode code) {
         return new ErrorResponse(code);
+    }
+
+    public ResponseEntity<String> entity() {
+        return ResponseEntity.status(this.status)
+                .body("{ \"message\" : \"" + this.message + "\", \"code\" : \"" + this.code + "\"}");
+    }
+
+    public String string() {
+        return "{ \"message\" : \"" + this.message + "\", \"code\" : \"" + this.code + "\"}";
     }
 }

--- a/src/main/java/com/gabozago/backend/error/ErrorResponse.java
+++ b/src/main/java/com/gabozago/backend/error/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.gabozago.backend.error;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ErrorResponse {
+
+    private String message;
+    private String code;
+    private int status;
+    private String detail;
+
+    public ErrorResponse(ErrorCode code) {
+        this.message = code.getMessage();
+        this.status = code.getStatus();
+        this.code = code.getCode();
+        this.detail = code.getDetail();
+    }
+
+    public static ErrorResponse of(ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+}

--- a/src/main/java/com/gabozago/backend/handler/BadResponseHandler.java
+++ b/src/main/java/com/gabozago/backend/handler/BadResponseHandler.java
@@ -1,0 +1,19 @@
+package com.gabozago.backend.handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
+
+@RestControllerAdvice
+public class BadResponseHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleJsonException(MethodArgumentNotValidException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("{\"message\": \"" + Objects.requireNonNull(e.getFieldError()).getDefaultMessage() + "\", \"code\": \"BAD_REQUEST\"}");
+    }
+}

--- a/src/main/java/com/gabozago/backend/jwt/AuthFilter.java
+++ b/src/main/java/com/gabozago/backend/jwt/AuthFilter.java
@@ -1,0 +1,33 @@
+package com.gabozago.backend.jwt;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class AuthFilter extends GenericFilterBean {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String token = tokenProvider.resolveToken((HttpServletRequest) request);
+        if (token != null && tokenProvider.validateToken(token)) {
+            Authentication auth = tokenProvider.getAuthentication(token);
+            if (auth != null) {
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } else {
+                SecurityContextHolder.clearContext();
+            }
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/gabozago/backend/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/gabozago/backend/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package com.gabozago.backend.jwt;
+
+import com.gabozago.backend.error.ErrorCode;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().println("{ \"message\" : \"" + ErrorCode.UNAUTHORIZED.getMessage()
+                + "\", \"code\" : \"" +  ErrorCode.UNAUTHORIZED.getCode()
+                + "\", \"success\" : " + false
+                + "}");
+    }
+
+}

--- a/src/main/java/com/gabozago/backend/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/gabozago/backend/jwt/JwtAccessDeniedHandler.java
@@ -1,6 +1,7 @@
 package com.gabozago.backend.jwt;
 
 import com.gabozago.backend.error.ErrorCode;
+import com.gabozago.backend.error.ErrorResponse;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -19,11 +20,8 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
     private void setResponse(HttpServletResponse response) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-        response.getWriter().println("{ \"message\" : \"" + ErrorCode.UNAUTHORIZED.getMessage()
-                + "\", \"code\" : \"" +  ErrorCode.UNAUTHORIZED.getCode()
-                + "\", \"success\" : " + false
-                + "}");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().println(ErrorResponse.of(ErrorCode.UNAUTHORIZED).string());
     }
 
 }

--- a/src/main/java/com/gabozago/backend/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/gabozago/backend/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,28 @@
+package com.gabozago.backend.jwt;
+
+import com.gabozago.backend.error.ErrorCode;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().println("{ \"message\" : \"" + ErrorCode.UNAUTHENTICATED.getMessage()
+                + "\", \"code\" : \"" +  ErrorCode.UNAUTHENTICATED.getCode()
+                + "\", \"success\" : " + false
+                + "}");
+    }
+}

--- a/src/main/java/com/gabozago/backend/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/gabozago/backend/jwt/JwtAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package com.gabozago.backend.jwt;
 
 import com.gabozago.backend.error.ErrorCode;
+import com.gabozago.backend.error.ErrorResponse;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -20,9 +21,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     private void setResponse(HttpServletResponse response) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-        response.getWriter().println("{ \"message\" : \"" + ErrorCode.UNAUTHENTICATED.getMessage()
-                + "\", \"code\" : \"" +  ErrorCode.UNAUTHENTICATED.getCode()
-                + "\", \"success\" : " + false
-                + "}");
+        response.getWriter().println(ErrorResponse.of(ErrorCode.UNAUTHENTICATED).string());
     }
 }

--- a/src/main/java/com/gabozago/backend/jwt/TokenProvider.java
+++ b/src/main/java/com/gabozago/backend/jwt/TokenProvider.java
@@ -22,8 +22,8 @@ public class TokenProvider {
         this.secretKey = Base64.getEncoder().encodeToString(secret.getBytes());
     }
 
-    public String createToken(String userID, List<String> roles) {
-        Claims claims = Jwts.claims().setSubject(userID);
+    public String createToken(Long userID, List<String> roles) {
+        Claims claims = Jwts.claims().setSubject(userID.toString());
         claims.put("roles", roles);
 
         // 7 days
@@ -35,5 +35,24 @@ public class TokenProvider {
                 .setExpiration(new Date(System.currentTimeMillis() + tokenLifeTime))
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
+    }
+
+    public Long getUserID(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public Boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            logger.error("Invalid JWT token: {}", e.getMessage());
+        }
+        return false;
     }
 }

--- a/src/main/java/com/gabozago/backend/jwt/TokenProvider.java
+++ b/src/main/java/com/gabozago/backend/jwt/TokenProvider.java
@@ -72,7 +72,16 @@ public class TokenProvider {
             return null;
         }
 
-        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserIdFromToken(token));
+        UserDetails userDetails;
+
+        try {
+            userDetails = userDetailsService.loadUserByUsername(this.getUserIdFromToken(token));
+        } catch (Exception e) {
+            logger.error("Get User Failed: {}", e.getMessage());
+
+            return null;
+        }
+
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 

--- a/src/main/java/com/gabozago/backend/jwt/TokenProvider.java
+++ b/src/main/java/com/gabozago/backend/jwt/TokenProvider.java
@@ -4,9 +4,9 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -20,15 +20,11 @@ import java.util.Date;
 import java.util.List;
 
 @Component
+@RequiredArgsConstructor
 public class TokenProvider {
     private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
     private final UserDetailsService userDetailsService;
     private String secretKey = "secret";
-
-    @Autowired
-    public TokenProvider(UserDetailsService userDetailsService) {
-        this.userDetailsService = userDetailsService;
-    }
 
     @PostConstruct
     protected void init() {

--- a/src/main/java/com/gabozago/backend/jwt/TokenProvider.java
+++ b/src/main/java/com/gabozago/backend/jwt/TokenProvider.java
@@ -3,11 +3,18 @@ package com.gabozago.backend.jwt;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -15,35 +22,31 @@ import java.util.List;
 @Component
 public class TokenProvider {
     private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
+    private final UserDetailsService userDetailsService;
+    private String secretKey = "secret";
 
-    private final String secretKey;
+    @Autowired
+    public TokenProvider(UserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
 
-    public TokenProvider(@Value("${jwt.secret}") String secret) {
-        this.secretKey = Base64.getEncoder().encodeToString(secret.getBytes());
+    @PostConstruct
+    protected void init() {
+        logger.info("Secret key: " + secretKey);
+        this.secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
     }
 
     public String createToken(Long userID, List<String> roles) {
         Claims claims = Jwts.claims().setSubject(userID.toString());
         claims.put("roles", roles);
 
-        // 7 days
-        long tokenLifeTime = 1000 * 60 * 60 * 24 * 7;
-
+        long expiration = 1000 * 60 * 60 * 24 * 7;
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + tokenLifeTime))
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
-    }
-
-    public Long getUserID(String token) {
-        Claims claims = Jwts.parser()
-                .setSigningKey(secretKey)
-                .parseClaimsJws(token)
-                .getBody();
-
-        return Long.parseLong(claims.getSubject());
     }
 
     public Boolean validateToken(String token) {
@@ -54,5 +57,26 @@ public class TokenProvider {
             logger.error("Invalid JWT token: {}", e.getMessage());
         }
         return false;
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public Authentication getAuthentication(String token) {
+        if (!validateToken(token)) {
+            return null;
+        }
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserIdFromToken(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    private String getUserIdFromToken(String token) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
     }
 }

--- a/src/main/java/com/gabozago/backend/jwt/TokenProvider.java
+++ b/src/main/java/com/gabozago/backend/jwt/TokenProvider.java
@@ -1,0 +1,39 @@
+package com.gabozago.backend.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+@Component
+public class TokenProvider {
+    private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
+
+    private final String secretKey;
+
+    public TokenProvider(@Value("${jwt.secret}") String secret) {
+        this.secretKey = Base64.getEncoder().encodeToString(secret.getBytes());
+    }
+
+    public String createToken(String userID, List<String> roles) {
+        Claims claims = Jwts.claims().setSubject(userID);
+        claims.put("roles", roles);
+
+        // 7 days
+        long tokenLifeTime = 1000 * 60 * 60 * 24 * 7;
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + tokenLifeTime))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/gabozago/backend/repository/UserRepository.java
+++ b/src/main/java/com/gabozago/backend/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String username);
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/gabozago/backend/repository/UserRepository.java
+++ b/src/main/java/com/gabozago/backend/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.gabozago.backend.repository;
+
+import com.gabozago.backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String username);
+}

--- a/src/main/java/com/gabozago/backend/service/UserService.java
+++ b/src/main/java/com/gabozago/backend/service/UserService.java
@@ -2,21 +2,17 @@ package com.gabozago.backend.service;
 
 import com.gabozago.backend.entity.User;
 import com.gabozago.backend.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserService implements UserDetailsService {
 
     private final UserRepository userRepository;
-
-    @Autowired
-    public UserService(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
 
     @Override
     public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {

--- a/src/main/java/com/gabozago/backend/service/UserService.java
+++ b/src/main/java/com/gabozago/backend/service/UserService.java
@@ -19,9 +19,9 @@ public class UserService implements UserDetailsService {
     }
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        long userId = Long.parseLong(id);
+        return userRepository.findById(userId).orElseThrow(() -> new UsernameNotFoundException("User not found"));
     }
 
     public void save(User user) {

--- a/src/main/java/com/gabozago/backend/service/UserService.java
+++ b/src/main/java/com/gabozago/backend/service/UserService.java
@@ -31,4 +31,12 @@ public class UserService implements UserDetailsService {
     public User findByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException("User not found"));
     }
+
+    public boolean checkExistsByEmail(String email) {
+        return userRepository.findByEmail(email).isPresent();
+    }
+
+    public boolean checkExistsByNickname(String nickname) {
+        return userRepository.findByNickname(nickname).isPresent();
+    }
 }

--- a/src/main/java/com/gabozago/backend/service/UserService.java
+++ b/src/main/java/com/gabozago/backend/service/UserService.java
@@ -1,0 +1,34 @@
+package com.gabozago.backend.service;
+
+import com.gabozago.backend.entity.User;
+import com.gabozago.backend.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+
+    public void save(User user) {
+        userRepository.save(user);
+    }
+
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+}

--- a/src/test/java/com/gabozago/backend/controller/AuthControllerTests.java
+++ b/src/test/java/com/gabozago/backend/controller/AuthControllerTests.java
@@ -1,5 +1,7 @@
 package com.gabozago.backend.controller;
 
+import com.gabozago.backend.dto.auth.JoinRequestDto;
+import com.gabozago.backend.dto.auth.LoginRequestDto;
 import com.gabozago.backend.entity.User;
 import com.gabozago.backend.error.ErrorCode;
 import com.gabozago.backend.jwt.TokenProvider;
@@ -86,6 +88,57 @@ public class AuthControllerTests {
     }
 
     @Test
+    @DisplayName("회원가입 @Valid 테스트 이메일이 없다면")
+    void testJoinValid_이메일() throws Exception {
+        mockMvc.perform(post("/auth/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept("*/*")
+                        .content("{\"email\": \"\", \"password\": \"password\", \"nickname\": \"test\"}"))
+                .andExpect(status().isBadRequest()).andExpect(result -> {
+                    String contentAsString = result.getResponse().getContentAsString();
+                    System.out.println(contentAsString);
+
+                    JSONObject jsonObject = new JSONObject(contentAsString);
+                    assert jsonObject.get("code").equals("BAD_REQUEST");
+                    assert jsonObject.get("message").equals(JoinRequestDto.EMAIL_NOT_NULL);
+                });
+    }
+
+    @Test
+    @DisplayName("회원가입 @Valid 테스트 비밀번호가 없다면")
+    void testJoinValid_비밀번호() throws Exception {
+        mockMvc.perform(post("/auth/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept("*/*")
+                        .content("{\"email\": \"test@example.com\", \"password\": \"\", \"nickname\": \"test\"}"))
+                .andExpect(status().isBadRequest()).andExpect(result -> {
+                    String contentAsString = result.getResponse().getContentAsString();
+                    System.out.println(contentAsString);
+
+                    JSONObject jsonObject = new JSONObject(contentAsString);
+                    assert jsonObject.get("code").equals("BAD_REQUEST");
+                    assert jsonObject.get("message").equals(JoinRequestDto.PASSWORD_NOT_NULL);
+                });
+    }
+
+    @Test
+    @DisplayName("회원가입 @Valid 테스트 닉네임이 없다면")
+    void testJoinValid_닉네임() throws Exception {
+        mockMvc.perform(post("/auth/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept("*/*")
+                        .content("{\"email\": \"test@example.com\", \"password\": \"password\", \"nickname\": \"\"}"))
+                .andExpect(status().isBadRequest()).andExpect(result -> {
+                    String contentAsString = result.getResponse().getContentAsString();
+                    System.out.println(contentAsString);
+
+                    JSONObject jsonObject = new JSONObject(contentAsString);
+                    assert jsonObject.get("code").equals("BAD_REQUEST");
+                    assert jsonObject.get("message").equals(JoinRequestDto.NICKNAME_NOT_NULL);
+                });
+    }
+
+    @Test
     @DisplayName("Test Login")
     void testLogin() throws Exception {
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
@@ -107,6 +160,41 @@ public class AuthControllerTests {
                         .content("{\"email\": \"test@example.com\", \"password\": \"password\", \"nickname\": \"test\"}"))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    @DisplayName("로그인 @Valid 테스트 이메일이 없다면")
+    void testLoginValid_이메일() throws Exception {
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept("*/*")
+                        .content("{\"email\": \"\", \"password\": \"password\", \"nickname\": \"test\"}"))
+                .andExpect(status().isBadRequest()).andExpect(result -> {
+                    String contentAsString = result.getResponse().getContentAsString();
+                    System.out.println(contentAsString);
+
+                    JSONObject jsonObject = new JSONObject(contentAsString);
+                    assert jsonObject.get("code").equals("BAD_REQUEST");
+                    assert jsonObject.get("message").equals(LoginRequestDto.EMAIL_NOT_NULL);
+                });
+    }
+
+    @Test
+    @DisplayName("로그인 @Valid 테스트 비밀번호가 없다면")
+    void testLoginValid_비밀번호() throws Exception {
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept("*/*")
+                        .content("{\"email\": \"test@example.com\", \"password\": \"\", \"nickname\": \"test\"}"))
+                .andExpect(status().isBadRequest()).andExpect(result -> {
+                    String contentAsString = result.getResponse().getContentAsString();
+                    System.out.println(contentAsString);
+
+                    JSONObject jsonObject = new JSONObject(contentAsString);
+                    assert jsonObject.get("code").equals("BAD_REQUEST");
+                    assert jsonObject.get("message").equals(LoginRequestDto.PASSWORD_NOT_NULL);
+                });
+    }
+
 
     @Test
     @DisplayName("Test Login with wrong password")

--- a/src/test/java/com/gabozago/backend/controller/AuthControllerTests.java
+++ b/src/test/java/com/gabozago/backend/controller/AuthControllerTests.java
@@ -1,0 +1,91 @@
+package com.gabozago.backend.controller;
+
+import com.gabozago.backend.entity.User;
+import com.gabozago.backend.jwt.TokenProvider;
+import com.gabozago.backend.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(controllers = AuthController.class)
+public class AuthControllerTests {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @MockBean
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("Test Join")
+    void testJoin() throws Exception {
+        mockMvc.perform(post("/auth/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept("*/*")
+                        .content("{\"email\": \"abc@abcd.com\", \"password\": \"password\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Test Login")
+    void testLogin() throws Exception {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        String encoded = encoder.encode("password");
+
+        Mockito.when(userService.findByEmail("abc@abcd.com"))
+                .thenReturn(User.builder()
+                        .id(1L)
+                        .email("abc@abcd.com")
+                        .password(encoded)
+                        .build());
+
+        Mockito.when(passwordEncoder.matches("password", encoded))
+                .thenReturn(true);
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept("*/*")
+                        .content("{\"email\": \"abc@abcd.com\", \"password\": \"password\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Test Login with wrong password")
+    void testLoginWithWrongPassword() throws Exception {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        String encoded = encoder.encode("passworld");
+
+        Mockito.when(userService.findByEmail("ppp@kakao.com"))
+                .thenReturn(User.builder()
+                        .id(1L)
+                        .email("ppp@kakao.com")
+                        .password(encoded)
+                        .build());
+
+        Mockito.when(passwordEncoder.matches("password", encoded))
+                .thenReturn(false);
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept("*/*")
+                        .content("{\"email\": \"ppp@kakao.com\", \"password\": \"password\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/gabozago/backend/jwt/TokenProviderTests.java
+++ b/src/test/java/com/gabozago/backend/jwt/TokenProviderTests.java
@@ -1,0 +1,29 @@
+package com.gabozago.backend.jwt;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TokenProviderTests {
+    TokenProvider tokenProvider;
+
+    @BeforeEach
+    public void init() {
+        tokenProvider = new TokenProvider("secret");
+    }
+
+    @Test
+    void testCreateToken() {
+        String token = tokenProvider.createToken("test", null);
+    }
+
+    @Test
+    void testCreateTokenWithRoles() {
+        String token = tokenProvider.createToken("test", List.of("ROLE_USER"));
+    }
+}
+

--- a/src/test/java/com/gabozago/backend/jwt/TokenProviderTests.java
+++ b/src/test/java/com/gabozago/backend/jwt/TokenProviderTests.java
@@ -1,36 +1,54 @@
 package com.gabozago.backend.jwt;
 
-
+import ch.qos.logback.classic.util.ContextInitializer;
+import com.gabozago.backend.entity.User;
+import com.gabozago.backend.service.UserService;
+import org.apache.tomcat.util.file.ConfigFileLoader;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
+@DisplayName("Token Provider Tests")
 public class TokenProviderTests {
     TokenProvider tokenProvider;
+    User user;
 
     @BeforeEach
     public void init() {
-        tokenProvider = new TokenProvider("secret");
+        user = User.builder().id(1L).email("test@example.com").username("user").password("password").build();
+        tokenProvider = new TokenProvider(new UserService(null) {
+            @Override
+            public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+                return user;
+            }
+
+            @Override
+            public void save(User user) {
+                // do nothing
+            }
+
+            @Override
+            public User findByEmail(String email) {
+                return user;
+            }
+        });
+
+
     }
 
     @Test
     void testCreateToken() {
-        String token = tokenProvider.createToken(1L, null);
+        tokenProvider.createToken(1L, null);
     }
 
     @Test
     void testCreateTokenWithRoles() {
-        String token = tokenProvider.createToken(1L, List.of("ROLE_USER"));
-    }
-
-    @Test
-    void testGetUserID() {
-        String token = tokenProvider.createToken(1L, null);
-        Long userID = tokenProvider.getUserID(token);
-        assertEquals(1L, userID);
+        tokenProvider.createToken(1L, List.of("ROLE_USER"));
     }
 
     @Test
@@ -44,6 +62,18 @@ public class TokenProviderTests {
     void testValidateTokenWithInvalidToken() {
         Boolean isValid = tokenProvider.validateToken("invalid token");
         assertEquals(false, isValid);
+    }
+
+    @Test
+    void testGetAuthentication() {
+        System.out.println(user.getId());
+        String token = tokenProvider.createToken(user.getId(), null);
+        tokenProvider.getAuthentication(token);
+    }
+
+    @Test
+    void testGetAuthenticationWithInvalidToken() {
+        tokenProvider.getAuthentication("invalid token");
     }
 }
 

--- a/src/test/java/com/gabozago/backend/jwt/TokenProviderTests.java
+++ b/src/test/java/com/gabozago/backend/jwt/TokenProviderTests.java
@@ -18,12 +18,32 @@ public class TokenProviderTests {
 
     @Test
     void testCreateToken() {
-        String token = tokenProvider.createToken("test", null);
+        String token = tokenProvider.createToken(1L, null);
     }
 
     @Test
     void testCreateTokenWithRoles() {
-        String token = tokenProvider.createToken("test", List.of("ROLE_USER"));
+        String token = tokenProvider.createToken(1L, List.of("ROLE_USER"));
+    }
+
+    @Test
+    void testGetUserID() {
+        String token = tokenProvider.createToken(1L, null);
+        Long userID = tokenProvider.getUserID(token);
+        assertEquals(1L, userID);
+    }
+
+    @Test
+    void testValidateToken() {
+        String token = tokenProvider.createToken(1L, null);
+        Boolean isValid = tokenProvider.validateToken(token);
+        assertEquals(true, isValid);
+    }
+
+    @Test
+    void testValidateTokenWithInvalidToken() {
+        Boolean isValid = tokenProvider.validateToken("invalid token");
+        assertEquals(false, isValid);
     }
 }
 

--- a/src/test/java/com/gabozago/backend/repository/UserRepositoryServiceTests.java
+++ b/src/test/java/com/gabozago/backend/repository/UserRepositoryServiceTests.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -39,9 +38,21 @@ public class UserRepositoryServiceTests {
 
         userRepository.save(user);
 
-        UserDetails userOptional = userRepository.findById(user.getId())
+        User userOptional = userRepository.findById(user.getId())
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
         assertEquals(userOptional.getUsername(), user.getUsername());
+    }
+
+    @Test
+    void testFindByNickname() {
+        User user = User.builder().username("user").nickname("test").password("password").build();
+
+        userRepository.save(user);
+
+        User userOptional = userRepository.findByNickname(user.getNickname())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        assertEquals(userOptional.getNickname(), "test");
     }
 }

--- a/src/test/java/com/gabozago/backend/repository/UserRepositoryServiceTests.java
+++ b/src/test/java/com/gabozago/backend/repository/UserRepositoryServiceTests.java
@@ -1,0 +1,47 @@
+package com.gabozago.backend.repository;
+
+import com.gabozago.backend.entity.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+public class UserRepositoryServiceTests {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    public void testFindByEmail() {
+        User user = User.builder().
+                email("rosejap97@gmail.com").
+                username("user").
+                password("password").
+                build();
+
+        userRepository.save(user);
+
+        User foundUser = userRepository.findByEmail(user.getEmail()).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        assertEquals(user, foundUser);
+    }
+
+
+    @Test
+    public void testFindById() {
+        User user = User.builder().username("user").password("password").build();
+
+        userRepository.save(user);
+
+        UserDetails userOptional = userRepository.findById(user.getId())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        assertEquals(userOptional.getUsername(), user.getUsername());
+    }
+}

--- a/src/test/java/com/gabozago/backend/service/UserServiceTests.java
+++ b/src/test/java/com/gabozago/backend/service/UserServiceTests.java
@@ -1,0 +1,59 @@
+package com.gabozago.backend.service;
+
+import com.gabozago.backend.repository.UserRepository;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+public class UserServiceTests {
+    UserService userService;
+
+    UserRepository userRepository;
+
+    @BeforeEach
+    public void setUp() {
+        userRepository = mock(UserRepository.class);
+        userService = new UserService(userRepository);
+    }
+
+    @Test
+    @DisplayName("유저중에 같은 이메일이 있다면 true를 반환한다.")
+    void testCheckExistsByEmail() {
+        String email = "test@example.com";
+        Mockito.when(userRepository.findByEmail(email)).
+                thenReturn(java.util.Optional.of(new com.gabozago.backend.entity.User()));
+
+        boolean userExists = userService.checkExistsByEmail("test@example.com");
+        assertTrue(userExists);
+    }
+
+    @Test
+    @DisplayName("유저중에 같은 이메일이 없다면 false를 반환한다.")
+    void testCheckExistsByEmail_유저가_없다면_false() {
+        boolean userExists = userService.checkExistsByEmail("test@example.com");
+        assertFalse(userExists);
+    }
+
+    @Test
+    @DisplayName("유저중에 같은 닉네임이 있다면 true를 반환한다.")
+    void testCheckExistsByNickname() {
+        String nickname = "test";
+        Mockito.when(userRepository.findByNickname(nickname)).
+                thenReturn(java.util.Optional.of(new com.gabozago.backend.entity.User()));
+
+        boolean userExists = userService.checkExistsByNickname("test");
+        assertTrue(userExists);
+    }
+
+    @Test
+    @DisplayName("유저중에 같은 닉네임이 없다면 false를 반환한다.")
+    void testCheckExistsByNickname_유저가_없다면_false() {
+        boolean userExists = userService.checkExistsByNickname("test");
+        assertFalse(userExists);
+    }
+}


### PR DESCRIPTION
## #10 `@Autowired` -> `@RequiredArgsConstructor`

의존성 주입 방식 수정

## #11 `@Valid`로 요청 데이터 검증

### 회원가입 요청 데이터에 이메일, 패스워드, 닉네임이 없는 경우

**POST** /auth/join

`400 Bad Request`

```
{
    "message": "email은 필수 입력값입니다.", 
    "code": "BAD_REQUEST"
}
```

```
{
    "message": "password는 필수 입력값입니다.", 
    "code": "BAD_REQUEST"
}
```

```
{
    "message": "nickname은 필수 입력값입니다.", 
    "code": "BAD_REQUEST"
}
```

### 로그인 요청 데이터에 이메일, 패스워드가 없는 경우

**POST** /auth/login

`400 Bad Request`

```
{
    "message": "email은 필수 입력값입니다.", 
    "code": "BAD_REQUEST"
}
```

```
{
    "message": "password는 필수 입력값입니다.", 
    "code": "BAD_REQUEST"
}
```